### PR TITLE
Fixed typo in help: see-lookup --> sse-lookup

### DIFF
--- a/speed.cpp
+++ b/speed.cpp
@@ -137,7 +137,7 @@ void print_help(const char* name) {
     std::printf("usage: %s function size iteration_count\n", name);
     std::puts("");
     std::puts("1. function - one of:");
-    std::puts("   * see-lookup              - SSSE3 variant using pshufb instruction");
+    std::puts("   * sse-lookup              - SSSE3 variant using pshufb instruction");
     std::puts("   * lookup-8                - lookup in std::uint8_t[256] LUT");
     std::puts("   * lookup-64               - lookup in std::uint64_t[256] LUT");
     std::puts("   * bit-parallel            - naive bit parallel method");


### PR DESCRIPTION
Simple documentation fix.
