### PR TITLE
Improved loop unrolling

### DIFF
--- a/popcnt-avx2-lookup.cpp
+++ b/popcnt-avx2-lookup.cpp
@@ -18,25 +18,33 @@ std::uint64_t popcnt_AVX2_lookup(const uint8_t* data, const size_t n) {
 
     __m256i acc = _mm256_setzero_si256();
 
-    while (i + 32 < n) {
+#define ITER { \
+        const __m256i vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data + i)); \
+        const __m256i lo  = _mm256_and_si256(vec, low_mask); \
+        const __m256i hi  = _mm256_and_si256(_mm256_srli_epi16(vec, 4), low_mask); \
+        const __m256i popcnt1 = _mm256_shuffle_epi8(lookup, lo); \
+        const __m256i popcnt2 = _mm256_shuffle_epi8(lookup, hi); \
+        local = _mm256_add_epi8(local, popcnt1); \
+        local = _mm256_add_epi8(local, popcnt2); \
+        i += 32; \
+    }
 
-        __m256i local = _mm256_setzero_si256(); 
-
-        for (int k=0; k < 255/8 && i + 32 < n; k++, i += 32) {
-            const __m256i vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data + i));
-            const __m256i lo  = _mm256_and_si256(vec, low_mask);
-            const __m256i hi  = _mm256_and_si256(_mm256_srli_epi16(vec, 4), low_mask);
-
-            const __m256i popcnt1 = _mm256_shuffle_epi8(lookup, lo);
-            const __m256i popcnt2 = _mm256_shuffle_epi8(lookup, hi);
-
-            local = _mm256_add_epi8(local, popcnt1);
-            local = _mm256_add_epi8(local, popcnt2);
-        }
-
+    while (i + 8*32 <= n) {
+        __m256i local = _mm256_setzero_si256();
+        ITER ITER ITER ITER
+        ITER ITER ITER ITER
         acc = _mm256_add_epi64(acc, _mm256_sad_epu8(local, _mm256_setzero_si256()));
     }
 
+    __m256i local = _mm256_setzero_si256();
+
+    while (i + 32 <= n) {
+        ITER;
+    }
+
+    acc = _mm256_add_epi64(acc, _mm256_sad_epu8(local, _mm256_setzero_si256()));
+
+#undef ITER
 
     uint64_t result = 0;
 

--- a/popcnt-bit-parallel-scalar.cpp
+++ b/popcnt-bit-parallel-scalar.cpp
@@ -2,25 +2,28 @@ std::uint64_t popcnt_parallel_64bit_naive(const uint8_t* data, const size_t n) {
 
     uint64_t result = 0;
 
-    for (size_t i=0; i < n; i += 8) {
-        
-        const uint64_t t1 = *reinterpret_cast<const uint64_t*>(data + i);
+    size_t i = 0;
 
-        const uint64_t t2 = (t1 & 0x5555555555555555llu) + ((t1 >>  1) & 0x5555555555555555llu);
-        const uint64_t t3 = (t2 & 0x3333333333333333llu) + ((t2 >>  2) & 0x3333333333333333llu);
-        const uint64_t t4 = (t3 & 0x0f0f0f0f0f0f0f0fllu) + ((t3 >>  4) & 0x0f0f0f0f0f0f0f0fllu);
-        const uint64_t t5 = (t4 & 0x00ff00ff00ff00ffllu) + ((t4 >>  8) & 0x00ff00ff00ff00ffllu);
-        const uint64_t t6 = (t5 & 0x0000ffff0000ffffllu) + ((t5 >> 16) & 0x0000ffff0000ffffllu);
-        const uint64_t t7 = (t6 & 0x00000000ffffffffllu) + ((t6 >> 32) & 0x00000000ffffffffllu);
-
-        result += t7;
+#define ITER { \
+        const uint64_t t1 = *reinterpret_cast<const uint64_t*>(data + i); \
+        const uint64_t t2 = (t1 & 0x5555555555555555llu) + ((t1 >>  1) & 0x5555555555555555llu); \
+        const uint64_t t3 = (t2 & 0x3333333333333333llu) + ((t2 >>  2) & 0x3333333333333333llu); \
+        const uint64_t t4 = (t3 & 0x0f0f0f0f0f0f0f0fllu) + ((t3 >>  4) & 0x0f0f0f0f0f0f0f0fllu); \
+        const uint64_t t5 = (t4 & 0x00ff00ff00ff00ffllu) + ((t4 >>  8) & 0x00ff00ff00ff00ffllu); \
+        const uint64_t t6 = (t5 & 0x0000ffff0000ffffllu) + ((t5 >> 16) & 0x0000ffff0000ffffllu); \
+        const uint64_t t7 = (t6 & 0x00000000ffffffffllu) + ((t6 >> 32) & 0x00000000ffffffffllu); \
+        result += t7; \
+        i += 8; \
     }
 
-    if (n % 8 != 0) {
+    while (i + 4*8 <= n) {
+        ITER ITER ITER ITER
+    }
 
-        for (size_t i = 8*(n/8); i < n; i++) {
-            result += lookup8bit[data[i]];
-        }
+#undef ITER
+
+    for (/**/; i < n; i++) {
+        result += lookup8bit[data[i]];
     }
 
     return result;
@@ -33,19 +36,22 @@ std::uint64_t popcnt_parallel_64bit_optimized(const uint8_t* data, const size_t 
 
     size_t i = 0;
 
-    while (i + 8 < n) {
+    while (i + 4*8 <= n) {
 
         uint64_t partial = 0; // packed_byte
 
-        for (int k = 0; i + 8 < n && k < 255/8; k++, i += 8) {
-            const uint64_t t1 = *reinterpret_cast<const uint64_t*>(data + i);
-
-            const uint64_t t2 = (t1 & 0x5555555555555555llu) + ((t1 >>  1) & 0x5555555555555555llu);
-            const uint64_t t3 = (t2 & 0x3333333333333333llu) + ((t2 >>  2) & 0x3333333333333333llu);
-            const uint64_t t4 = (t3 & 0x0f0f0f0f0f0f0f0fllu) + ((t3 >>  4) & 0x0f0f0f0f0f0f0f0fllu);
-
-            partial += t4;
+#define ITER { \
+            const uint64_t t1 = *reinterpret_cast<const uint64_t*>(data + i); \
+            const uint64_t t2 = (t1 & 0x5555555555555555llu) + ((t1 >>  1) & 0x5555555555555555llu); \
+            const uint64_t t3 = (t2 & 0x3333333333333333llu) + ((t2 >>  2) & 0x3333333333333333llu); \
+            const uint64_t t4 = (t3 & 0x0f0f0f0f0f0f0f0fllu) + ((t3 >>  4) & 0x0f0f0f0f0f0f0f0fllu); \
+            partial += t4; \
+            i += 8; \
         }
+
+        ITER ITER ITER ITER
+
+#undef ITER
 
         const uint64_t t5 = (partial & 0x00ff00ff00ff00ffllu) + ((partial >>  8) & 0x00ff00ff00ff00ffllu);
         const uint64_t t6 = (t5 & 0x0000ffff0000ffffllu) + ((t5 >> 16) & 0x0000ffff0000ffffllu);

--- a/popcnt-cpu.cpp
+++ b/popcnt-cpu.cpp
@@ -2,14 +2,22 @@ std::uint64_t popcnt_cpu_64bit(const uint8_t* data, const size_t n) {
 
     uint64_t result = 0;
 
-    for (size_t i=0; i < n; i += 8) {
-        const uint64_t v = *reinterpret_cast<const uint64_t*>(data + i);
-
-        result += _popcnt64(v);
+    uint64_t v, i = 0;
+#define ITER { \
+        v = *reinterpret_cast<const uint64_t*>(data + i); \
+        result += _popcnt64(v); \
+        i += 8; \
     }
 
-    for (size_t i=8*(n/8); i < n; i++) {
+    while (i + 4*8 <= n) {
+        ITER ITER ITER ITER
+    }
+
+#undef ITER
+
+    while (i < n) {
         result += lookup8bit[data[i]];
+        i++;
     }
 
     return result;

--- a/popcnt-lookup.cpp
+++ b/popcnt-lookup.cpp
@@ -140,8 +140,16 @@ std::uint64_t popcnt_lookup_8bit(const uint8_t* data, const size_t n) {
     
     size_t result = 0;
 
-    for (size_t i=0; i < n; i++) {
-        result += lookup8bit[data[i]];
+    size_t i = 0;
+    while (i + 4 <= n) {
+        result += lookup8bit[data[i]]; i++;
+        result += lookup8bit[data[i]]; i++;
+        result += lookup8bit[data[i]]; i++;
+        result += lookup8bit[data[i]]; i++;
+    }
+
+    while (i < n) {
+        result += lookup8bit[data[i]]; i++;
     }
 
     return result;
@@ -152,8 +160,16 @@ std::uint64_t popcnt_lookup_64bit(const uint8_t* data, const size_t n) {
     
     size_t result = 0;
 
-    for (size_t i=0; i < n; i++) {
-        result += lookup64bit[data[i]];
+    size_t i = 0;
+    while (i + 4 <= n) {
+        result += lookup64bit[data[i]]; i++;
+        result += lookup64bit[data[i]]; i++;
+        result += lookup64bit[data[i]]; i++;
+        result += lookup64bit[data[i]]; i++;
+    }
+
+    while (i < n) {
+        result += lookup64bit[data[i]]; i++;
     }
 
     return result;

--- a/popcnt-sse-bit-parallel.cpp
+++ b/popcnt-sse-bit-parallel.cpp
@@ -8,19 +8,22 @@ std::uint64_t popcnt_SSE_bit_parallel(const uint8_t* data, const size_t n) {
 
     __m128i acc = _mm_setzero_si128();
 
-    while (i + 16 < n) {
+    while (i + 4*16 < n) {
 
         __m128i partial = _mm_setzero_si128(); 
 
-        for (int k=0; k < 255/8 && i + 16 < n; k++, i += 16) {
-            const __m128i t1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + i));
-
-            const __m128i t2 = (t1 & pattern_2bit)  + ((t1 >> shift16(1)) & pattern_2bit);
-            const __m128i t3 = (t2 & pattern_4bit)  + ((t2 >> shift16(2)) & pattern_4bit);
-            const __m128i t4 = (t3 & pattern_16bit) + ((t3 >> shift16(4)) & pattern_16bit);
-
-            partial = _mm_add_epi8(partial, t4);
+#define ITER { \
+            const __m128i t1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + i)); \
+            const __m128i t2 = (t1 & pattern_2bit)  + ((t1 >> shift16(1)) & pattern_2bit); \
+            const __m128i t3 = (t2 & pattern_4bit)  + ((t2 >> shift16(2)) & pattern_4bit); \
+            const __m128i t4 = (t3 & pattern_16bit) + ((t3 >> shift16(4)) & pattern_16bit); \
+            partial = _mm_add_epi8(partial, t4); \
+            i += 16; \
         }
+
+        ITER ITER ITER ITER
+
+#undef ITER
 
         acc = _mm_add_epi64(acc, _mm_sad_epu8(partial, _mm_setzero_si128()));
     }

--- a/popcnt-sse-lookup.cpp
+++ b/popcnt-sse-lookup.cpp
@@ -13,24 +13,33 @@ std::uint64_t popcnt_SSE_lookup(const uint8_t* data, const size_t n) {
 
     __m128i acc = _mm_setzero_si128();
 
-    while (i + 16 < n) {
+#define ITER { \
+        const __m128i vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + i)); \
+        const __m128i lo  = vec & low_mask; \
+        const __m128i hi  = (vec >> shift16(4)) & low_mask; \
+        const __m128i popcnt1 = _mm_shuffle_epi8(lookup, lo); \
+        const __m128i popcnt2 = _mm_shuffle_epi8(lookup, hi); \
+        local = _mm_add_epi8(local, popcnt1); \
+        local = _mm_add_epi8(local, popcnt2); \
+        i += 16; \
+    }
 
-        __m128i local = _mm_setzero_si128(); 
-
-        for (int k=0; k < 255/8 && i + 16 < n; k++, i += 16) {
-            const __m128i vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + i));
-            const __m128i lo  = vec & low_mask;
-            const __m128i hi  = (vec >> shift16(4)) & low_mask;
-
-            const __m128i popcnt1 = _mm_shuffle_epi8(lookup, lo);
-            const __m128i popcnt2 = _mm_shuffle_epi8(lookup, hi);
-
-            local = _mm_add_epi8(local, popcnt1);
-            local = _mm_add_epi8(local, popcnt2);
-        }
-
+    while (i + 8*16 <= n) {
+        __m128i local = _mm_setzero_si128();
+        ITER ITER ITER ITER
+        ITER ITER ITER ITER
         acc = _mm_add_epi64(acc, _mm_sad_epu8(local, _mm_setzero_si128()));
     }
+
+    __m128i local = _mm_setzero_si128();
+
+    while (i + 16 <= n) {
+        ITER
+    }
+
+    acc = _mm_add_epi64(acc, _mm_sad_epu8(local, _mm_setzero_si128()));
+
+#undef ITER
 
     size_t result = lower_qword(acc) + higher_qword(acc);
 

--- a/verify.cpp
+++ b/verify.cpp
@@ -45,7 +45,7 @@ function_t functions[] = {
     {false, "avx2-lookup",             popcnt_AVX2_lookup},
 #endif
 #if defined(HAVE_POPCNT_INSTRUCTION)
-    {false, "cpu",                     popcnt_SSE_lookup},
+    {false, "cpu",                     popcnt_cpu_64bit},
 #endif
     {false, nullptr, nullptr}
 };


### PR DESCRIPTION
Adds loop unrolling mostly everywhere, improving each version's running time by ~30%.

Before:

```
$ ./speed_avx2 10000 1000000
LUT (uint8_t[256])            ... time = 5.239423 s
LUT (uint64_t[256])           ... time = 5.792041 s (speedup: 0.90)
bit parallel                  ... time = 5.328451 s (speedup: 0.98)
bit parallel optimized        ... time = 3.660314 s (speedup: 1.43)
bit parallel optimized - SSE  ... time = 1.425489 s (speedup: 3.68)
SSSE3 [pshufb]                ... time = 0.977139 s (speedup: 5.36)
AVX2 [pshufb]                 ... time = 0.534345 s (speedup: 9.81)
CPU popcnt                    ... time = 0.773064 s (speedup: 6.78)
```

After:

```
$ ./speed_avx2 10000 1000000
LUT (uint8_t[256])            ... time = 4.322537 s
LUT (uint64_t[256])           ... time = 4.279465 s (speedup: 1.01)
bit parallel                  ... time = 4.223320 s (speedup: 1.02)
bit parallel optimized        ... time = 2.698201 s (speedup: 1.60)
bit parallel optimized - SSE  ... time = 1.241662 s (speedup: 3.48)
SSSE3 [pshufb]                ... time = 0.666053 s (speedup: 6.49)
AVX2 [pshufb]                 ... time = 0.352794 s (speedup: 12.25)
CPU popcnt                    ... time = 0.518836 s (speedup: 8.33)
```
