### PR TITLE
Add Harley-Seal popcount algorithm

### DIFF
--- a/popcnt-harley-seal.cpp
+++ b/popcnt-harley-seal.cpp
@@ -1,0 +1,88 @@
+namespace {
+
+/// This uses fewer arithmetic operations than any other known  
+/// implementation on machines with fast multiplication.
+/// It uses 12 arithmetic operations, one of which is a multiply.
+/// http://en.wikipedia.org/wiki/Hamming_weight#Efficient_implementation
+///
+uint64_t popcount_mul(uint64_t x)
+{
+  const uint64_t m1  = UINT64_C(0x5555555555555555);
+  const uint64_t m2  = UINT64_C(0x3333333333333333);
+  const uint64_t m4  = UINT64_C(0x0F0F0F0F0F0F0F0F);
+  const uint64_t h01 = UINT64_C(0x0101010101010101);
+
+  x -=            (x >> 1)  & m1;
+  x = (x & m2) + ((x >> 2)  & m2);
+  x = (x +        (x >> 4)) & m4;
+  return (x * h01) >> 56;
+}
+
+/// Carry-save adder (CSA).
+/// @see Chapter 5 in "Hacker's Delight".
+///
+void CSA(uint64_t& h, uint64_t& l, uint64_t a, uint64_t b, uint64_t c)
+{
+  uint64_t u = a ^ b; 
+  h = (a & b) | (u & c);
+  l = u ^ c;
+}
+
+/// Harley-Seal popcount (4th iteration).
+/// The Harley-Seal popcount algorithm is one of the fastest algorithms
+/// for counting 1 bits in an array using only integer operations.
+/// This implementation uses only 5.69 instructions per 64-bit word.
+/// @see Chapter 5 in "Hacker's Delight" 2nd edition.
+///
+uint64_t popcnt_harley_seal_64bit(const uint64_t* data, const uint64_t size)
+{
+  uint64_t total = 0;
+  uint64_t ones = 0, twos = 0, fours = 0, eights = 0, sixteens = 0;
+  uint64_t twosA, twosB, foursA, foursB, eightsA, eightsB;
+  uint64_t limit = size - size % 16;
+  uint64_t i = 0;
+
+  for(; i < limit; i += 16)
+  {
+    CSA(twosA, ones, ones, data[i+0], data[i+1]);
+    CSA(twosB, ones, ones, data[i+2], data[i+3]);
+    CSA(foursA, twos, twos, twosA, twosB);    
+    CSA(twosA, ones, ones, data[i+4], data[i+5]);
+    CSA(twosB, ones, ones, data[i+6], data[i+7]);
+    CSA(foursB, twos, twos, twosA, twosB);    
+    CSA(eightsA,fours, fours, foursA, foursB);
+    CSA(twosA, ones, ones, data[i+8], data[i+9]);
+    CSA(twosB, ones, ones, data[i+10], data[i+11]);
+    CSA(foursA, twos, twos, twosA, twosB);
+    CSA(twosA, ones, ones, data[i+12], data[i+13]);
+    CSA(twosB, ones, ones, data[i+14], data[i+15]);
+    CSA(foursB, twos, twos, twosA, twosB);    
+    CSA(eightsB, fours, fours, foursA, foursB);
+    CSA(sixteens, eights, eights, eightsA, eightsB);
+
+    total += popcount_mul(sixteens);
+  }
+
+  total *= 16;
+  total += 8 * popcount_mul(eights);
+  total += 4 * popcount_mul(fours);
+  total += 2 * popcount_mul(twos);
+  total += 1 * popcount_mul(ones);
+
+  for(; i < size; i++)
+    total += popcount_mul(data[i]);
+
+  return total;
+}
+
+} // namespace
+
+uint64_t popcnt_harley_seal(const uint8_t* data, const size_t size)
+{
+  uint64_t total = popcnt_harley_seal_64bit((const uint64_t*) data, size / 8);
+
+  for (size_t i = size - size % 8; i < size; i++)
+    total += lookup8bit[data[i]];
+
+  return total;
+}

--- a/speed.cpp
+++ b/speed.cpp
@@ -15,6 +15,7 @@
 
 #include "popcnt-lookup.cpp"
 #include "popcnt-bit-parallel-scalar.cpp"
+#include "popcnt-harley-seal.cpp"
 
 #include "sse_operators.cpp"
 #include "popcnt-sse-bit-parallel.cpp"
@@ -157,6 +158,15 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    if (functions.empty() || functions.count("harley-seal")) {
+
+        auto result = run(popcnt_harley_seal, "harley-seal", data, size, count, time);
+        n += result.count;
+        if (time == 0.0) {
+            time = result.time;
+        }
+    }
+
     if (functions.empty() || functions.count("sse-bit-parallel")) {
 
         auto result = run(popcnt_SSE_bit_parallel, "bit parallel optimized - SSE", data, size, count, time);
@@ -219,6 +229,7 @@ void print_help(const char* name) {
     std::puts("   * lookup-64               - lookup in std::uint64_t[256] LUT");
     std::puts("   * bit-parallel            - naive bit parallel method");
     std::puts("   * bit-parallel-optimized  - a bit better bit parallel");
+    std::puts("   * harley-seal             - Harley-Seal popcount (4th iteration)");
     std::puts("   * sse-bit-parallel        - SSE implementation of bit-parallel-optimized");
 #if defined(HAVE_POPCNT_INSTRUCTION)
     std::puts("   * cpu                     - CPU instruction popcnt (64-bit variant)");
@@ -232,6 +243,7 @@ bool is_name_valid(const std::string& name) {
         || (name == "lookup-64")
         || (name == "bit-parallel")
         || (name == "bit-parallel-optimized")
+        || (name == "harley-seal")
         || (name == "sse-bit-parallel")
         || (name == "sse-lookup")
 #if defined(HAVE_AVX2_INSTRUCTIONS)

--- a/verify.cpp
+++ b/verify.cpp
@@ -15,6 +15,7 @@
 
 #include "popcnt-lookup.cpp"
 #include "popcnt-bit-parallel-scalar.cpp"
+#include "popcnt-harley-seal.cpp"
 
 #include "sse_operators.cpp"
 #include "popcnt-sse-bit-parallel.cpp"
@@ -39,6 +40,7 @@ function_t functions[] = {
     {true,  "lookup-64",               popcnt_lookup_64bit},
     {false, "bit-parallel",            popcnt_parallel_64bit_naive},
     {false, "bit-parallel-optimized",  popcnt_parallel_64bit_optimized},
+    {false, "harley-seal",             popcnt_harley_seal},
     {false, "sse-bit-parallel",        popcnt_SSE_bit_parallel},
     {false, "sse-lookup",              popcnt_SSE_lookup},
 #if defined(HAVE_AVX2_INSTRUCTIONS)


### PR DESCRIPTION
Hi,

Please add the Harley-Seal popcount algorithm. To the best of my knowledge this is the fastest known algorithm which uses only integer instructions, hence it works on all CPUs. The algorithm is described in depth in the Hacker's Delight book (second edition) and you can probably also find the original paper on the web.

Here are the results on my Intel Core i7-6700 CPU @ 3.40GHz (Linux x86-64, GCC-5.2):

```
./speed_avx2 10000000 1000
LUT (uint8_t[256])            ... time = 2.711632 s
LUT (uint64_t[256])           ... time = 2.572202 s (speedup: 1.05)
bit parallel                  ... time = 2.591368 s (speedup: 1.05)
bit parallel optimized        ... time = 1.703079 s (speedup: 1.59)
harley-seal                   ... time = 0.790219 s (speedup: 3.43)
bit parallel optimized - SSE  ... time = 0.833144 s (speedup: 3.25)
SSSE3 [pshufb]                ... time = 0.543871 s (speedup: 4.99)
AVX2 [pshufb]                 ... time = 0.403595 s (speedup: 6.72)
CPU popcnt                    ... time = 0.466106 s (speedup: 5.82)
kim@kim-skylake:~/Desktop/sse-popcount$ ./verify_avx2 

test 'all zeros':
bit-parallel                  : OK
bit-parallel-optimized        : OK
harley-seal                   : OK
sse-bit-parallel              : OK
sse-lookup                    : OK
avx2-lookup                   : OK
cpu                           : OK

test 'all ones':
bit-parallel                  : OK
bit-parallel-optimized        : OK
harley-seal                   : OK
sse-bit-parallel              : OK
sse-lookup                    : OK
avx2-lookup                   : OK
cpu                           : OK

test 'asending':
bit-parallel                  : OK
bit-parallel-optimized        : OK
harley-seal                   : OK
sse-bit-parallel              : OK
sse-lookup                    : OK
avx2-lookup                   : OK
cpu                           : OK

test 'quasirandom':
bit-parallel                  : OK
bit-parallel-optimized        : OK
harley-seal                   : OK
sse-bit-parallel              : OK
sse-lookup                    : OK
avx2-lookup                   : OK
cpu                           : OK
```

P.S. you might want to change the algorithm description:

```
harley-seal             - Harley-Seal popcount (4th iteration)
```

to what ever you want.
