### PR TITLE
Add AVX compile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,14 @@ FLAGS=-std=c++11 -mpopcnt -O2 -Wall -pedantic -Wextra
 
 DEPS=popcnt-*.cpp config.h
 ALL=speed verify
+ALL_AVX=speed_avx verify_avx
 ALL_AVX2=speed_avx2 verify_avx2
 
-.PHONY: all avx2
+.PHONY: all avx avx2
 
 all: $(ALL)
+
+avx: $(ALL_AVX)
 
 avx2: $(ALL_AVX2)
 
@@ -16,6 +19,12 @@ speed: $(DEPS) speed.cpp
 
 verify: $(DEPS) verify.cpp
 	$(CC) $(FLAGS) -mssse3 verify.cpp -o $@
+
+speed_avx: $(DEPS) speed.cpp
+	$(CC) $(FLAGS) -mavx speed.cpp -o $@
+
+verify_avx: $(DEPS) verify.cpp
+	$(CC) $(FLAGS) -mavx verify.cpp -o $@
 
 speed_avx2: $(DEPS) speed.cpp
 	$(CC) $(FLAGS) -mavx2 -DHAVE_AVX2_INSTRUCTIONS speed.cpp -o $@
@@ -29,8 +38,11 @@ ITERS=1000
 run: speed
 	./speed $(SIZE) $(ITERS)
 
+run_avx: speed_avx
+	./speed_avx $(SIZE) $(ITERS)
+
 run_avx2: speed_avx2
 	./speed_avx2 $(SIZE) $(ITERS)
 
 clean:
-	rm -f $(ALL) $(ALL_AVX2)
+	rm -f $(ALL) $(ALL_AVX) $(ALL_AVX2)


### PR DESCRIPTION
Testing showed that SSSE3 [pshufb] algorithm performed on par with, or better than, the CPU popcnt when compiled with AVX instruction set.
i7 3930K @ 3.2GHz, Ubuntu 14.04, gcc 4.8.5

```
./speed_avx 10000000 1000
LUT (uint8_t[256])            ... time = 3.541451 s
LUT (uint64_t[256])           ... time = 3.526974 s (speedup: 1.00)
bit parallel                  ... time = 4.137992 s (speedup: 0.86)
bit parallel optimized        ... time = 2.734398 s (speedup: 1.30)
Harley-Seal popcount          ... time = 1.099396 s (speedup: 3.22)
bit parallel optimized - SSE  ... time = 0.989633 s (speedup: 3.58)
SSSE3 [pshufb]                ... time = 0.635334 s (speedup: 5.57)
CPU popcnt                    ... time = 0.662304 s (speedup: 5.35)
```
