### PR TITLE
Various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
         speed_aarch64 verify_aarch64
 
 COMPILER=$(notdir $(CXX))
-FLAGS=-std=c++11 -O2 -Wall -pedantic -Wextra -Wfatal-errors
+FLAGS=-std=c++17 -O2 -Wall -pedantic -Wextra -Wfatal-errors
 FLAGS_INTEL=$(FLAGS) -mpopcnt -fabi-version=6
 FLAGS_ARM=$(FLAGS) -mfpu=neon -DHAVE_NEON_INSTRUCTIONS
 # It seems that for AArch64 no extra flags are needed (NEON is always available)

--- a/results/report.sh
+++ b/results/report.sh
@@ -25,7 +25,7 @@ if [[ ! -f $SCRIPT ]]; then
     exit 1
 fi
 
-REPORT="python ${SCRIPT}"
+REPORT="python2 ${SCRIPT}"
 
 for file in ${DIR}/*.metadata
 do

--- a/verify.cpp
+++ b/verify.cpp
@@ -146,7 +146,7 @@ void Application::verify(const char* name) {
             puts("OK", GREEN);
         } else {
             puts("ERROR", RED);
-            printf("result = %lu, reference = %lu\n", result, reference);
+            printf("result = %llu, reference = %llu\n", result, reference);
             failed = true;
         }
     }


### PR DESCRIPTION
Hi!

I ran into a few issues getting this running on newer gcc versions. The issues were:

- `posix_memalign` doesn't exist everywhere, so it needs to be emulated with `_allocate_align` if it isn't present.
- the `data` pointer wasn't guaranteed to be 64 byte aligned, so this broke some cases with stack alignment when `_m256i` args were passed to the AVX512 functions (this might actually be a gcc bug. it's fixed by making the pointer field itself 64-byte aligned; this appears to propagate the alignedness to stack accesses so args either get 64-byte aligned on the stack or a `vmovdqu64` is emitted instead of `vmovdqa64`)
- python scripts need explicitly running with python2 these days
- speedup wasn't getting flushed to stdout when the process exited so CSVs were getting mangled
- some various warnings about string formats

I've patched these issues and the code now compiles and works properly.

I'll open a separate PR for benchmarks on a Xeon Scalable 8276L (Cascade Lake) under gcc 13.2.0 on MSYS.