### PR TITLE
Patches for AVX512VPOPCNTDQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
         speed_avx2 verify_avx2 \
         speed_avx512bw verify_avx512bw \
         speed_avx512vbmi verify_avx512vbmi \
-        verify_avx512vpopcnt \
+        speed_avx512vpopcnt verify_avx512vpopcnt \
         speed_arm verify_arm \
         speed_aarch64 verify_aarch64
 
@@ -32,7 +32,7 @@ ALL_AVX=speed_avx_$(COMPILER) verify_avx_$(COMPILER)
 ALL_AVX2=speed_avx2_$(COMPILER) verify_avx2_$(COMPILER)
 ALL_AVX512BW=speed_avx512bw_$(COMPILER) verify_avx512bw_$(COMPILER)
 ALL_AVX512VBMI=speed_avx512vbmi_$(COMPILER) verify_avx512vbmi_$(COMPILER)
-ALL_AVX512VPOPCNT=verify_avx512vpopcnt_$(COMPILER)
+ALL_AVX512VPOPCNT=speed_avx512vpopcnt_$(COMPILER) verify_avx512vpopcnt_$(COMPILER)
 ALL_ARM=speed_arm_$(COMPILER) verify_arm_$(COMPILER)
 ALL_AARCH64=speed_aarch64_$(COMPILER) verify_aarch64_$(COMPILER)
 ALL_TARGETS=$(ALL) $(ALL_AVX) $(ALL_AVX2) $(ALL_AVX512) $(ALL_AVX512BW) $(ALL_AVX512VPOPCNT)
@@ -60,6 +60,10 @@ help:
 	@echo "avx512vbmi            - makes programs verify_avx512vbmi & speed_avx512vbmi"
 	@echo "run_avx512vbmi        - runs benchmark program"
 	@echo "run_verify_avx512vbmi - runs verification program"
+	@echo
+	@echo "avx512vpopcnt            - makes programs verify_avx512vpopcnt & speed_avx512vpopcnt"
+	@echo "run_avx512vpopcnt        - runs benchmark program"
+	@echo "run_verify_avx512vpopcnt - runs verification program"
 	@echo
 	@echo "ARM Neon target:"
 	@echo "arm                   - makes programs verify_arm & speed_arm (using Neon instructions)"
@@ -112,6 +116,9 @@ speed_avx512vbmi_$(COMPILER): $(DEPS) speed.cpp
 verify_avx512vbmi_$(COMPILER): $(DEPS) verify.cpp
 	$(CXX) $(FLAGS_AVX512VBMI) verify.cpp -o $@
 
+speed_avx512vpopcnt_$(COMPILER): $(DEPS) speed.cpp
+	$(CXX) $(FLAGS_AVX512VPOPCNT) speed.cpp -o $@
+
 verify_avx512vpopcnt_$(COMPILER): $(DEPS) verify.cpp
 	$(CXX) $(FLAGS_AVX512VPOPCNT) verify.cpp -o $@
 
@@ -132,6 +139,7 @@ speed_avx: speed_avx_$(COMPILER)
 speed_avx2: speed_avx2_$(COMPILER)
 speed_avx512bw: speed_avx512bw_$(COMPILER)
 speed_avx512vbmi: speed_avx512vbmi_$(COMPILER)
+speed_avx512vpopcnt: speed_avx512vpopcnt_$(COMPILER)
 speed_arm: speed_arm_$(COMPILER)
 speed_aarch64: speed_aarch64_$(COMPILER)
 
@@ -140,6 +148,7 @@ verify_avx: verify_avx_$(COMPILER)
 verify_avx2: verify_avx2_$(COMPILER)
 verify_avx512bw: verify_avx512bw_$(COMPILER)
 verify_avx512vbmi: verify_avx512vbmi_$(COMPILER)
+verify_avx512vpopcnt: verify_avx512vpopcnt_$(COMPILER)
 verify_arm: verify_arm_$(COMPILER)
 verify_aarch64: verify_aarch64_$(COMPILER)
 
@@ -186,6 +195,9 @@ run_verify_avx512bw: verify_avx512bw_$(COMPILER)
 	./$^
 
 run_verify_avx512vbmi: verify_avx512vbmi_$(COMPILER)
+	./$^
+
+run_verify_avx512vpopcnt: verify_avx512vpopcnt_$(COMPILER)
 	./$^
 
 run_verify_arm: verify_arm_$(COMPILER)

--- a/function_registry.cpp
+++ b/function_registry.cpp
@@ -200,7 +200,7 @@ void FunctionRegistry::build() {
 #if defined(HAVE_AVX512VPOPCNT_INSTRUCTIONS)
     add("avx512-vpopcnt",
         "AVX512 VPOPCNT",
-        avx512_vpopcnt);
+        popcnt_AVX512_vpopcnt);
 #endif
 
     add("builtin-popcnt",

--- a/popcnt-avx512-vpopcnt.cpp
+++ b/popcnt-avx512-vpopcnt.cpp
@@ -1,4 +1,4 @@
-uint64_t avx512_vpopcnt(const uint8_t* data, const size_t size) {
+std::uint64_t popcnt_AVX512_vpopcnt(const uint8_t* data, const size_t size) {
     
     const size_t chunks = size / 64;
 

--- a/popcnt-avx512-vpopcnt.cpp
+++ b/popcnt-avx512-vpopcnt.cpp
@@ -1,40 +1,27 @@
-std::uint64_t popcnt_AVX512_vpopcnt(const uint8_t* data, const size_t size) {
-    
-    const size_t chunks = size / 64;
+std::uint64_t popcnt_AVX512_vpopcnt(const uint8_t *data, const size_t size)
+{
 
-    uint8_t* ptr = const_cast<uint8_t*>(data);
-    const uint8_t* end = ptr + size;
+    const size_t chunks = size / 64;
+    uint8_t *ptr = const_cast<uint8_t *>(data);
+    const uint8_t *end = ptr + size;
 
     // count using AVX512 registers
     __m512i accumulator = _mm512_setzero_si512();
-    for (size_t i=0; i < chunks; i++, ptr += 64) {
-        
-        // Note: a short chain of dependencies, likely unrolling will be needed.
-        const __m512i v = _mm512_loadu_si512((const __m512i*)ptr);
+    for (size_t i = 0; i < chunks; i++, ptr += 64)
+    {
+        const __m512i v = _mm512_loadu_si512((const __m512i *)ptr);
         const __m512i p = _mm512_popcnt_epi64(v);
-
         accumulator = _mm512_add_epi64(accumulator, p);
     }
 
-    // horizontal sum of a register
-    uint64_t tmp[8] __attribute__((aligned(64)));
-    _mm512_store_si512((__m512i*)tmp, accumulator);
-
-    uint64_t total = 0;
-    for (size_t i=0; i < 8; i++) {
-        total += tmp[i];
+    // use masked instrucitons for the tail
+    if (ptr < end)
+    {
+        __mmask8 mask = (__mmask8)_bzhi_u32(0xFFFFFFFF, end - ptr);
+        const __m512i v = _mm512_maskz_loadu_epi64(mask, ptr);
+        const __m512i p = _mm512_popcnt_epi64(v);
+        accumulator = _mm512_add_epi64(accumulator, p);
     }
 
-    // popcount the tail
-    while (ptr + 8 < end) {
-        total += _mm_popcnt_u64(*reinterpret_cast<const uint64_t*>(ptr));
-        ptr += 8;
-    }
-
-    while (ptr < end) {
-        total += lookup8bit[*ptr++];
-    }
-
-    return total;
+    return _mm512_reduce_add_epi64(accumulator);
 }
-

--- a/speed.cpp
+++ b/speed.cpp
@@ -293,7 +293,7 @@ Application::Result Application::run(const std::string& name, FN function, doubl
     Result result;
 
     if (cmd.print_csv) {
-        printf("%s, %llu, %llu, ", name.c_str(), cmd.size, cmd.iteration_count);
+        printf("%s, %zu, %zu, ", name.c_str(), cmd.size, cmd.iteration_count);
         fflush(stdout);
     } else {
         const auto& dsc = names.get(name);

--- a/speed.cpp
+++ b/speed.cpp
@@ -248,6 +248,10 @@ void Application::run_procedure(const std::string& name) {
     RUN("avx512vbmi-shuf",      popcnt_AVX512VBMI_lookup);
 #endif
 
+#if defined(HAVE_AVX512VPOPCNT_INSTRUCTIONS)
+    RUN("avx512-vpopcnt",       popcnt_AVX512_vpopcnt);
+#endif
+
 #if defined(HAVE_POPCNT_INSTRUCTION)
     RUN("cpu", popcnt_cpu_64bit);
 #endif

--- a/verify.cpp
+++ b/verify.cpp
@@ -146,7 +146,7 @@ void Application::verify(const char* name) {
             puts("OK", GREEN);
         } else {
             puts("ERROR", RED);
-            printf("result = %llu, reference = %llu\n", result, reference);
+            printf("result = %zu, reference = %zu\n", result, reference);
             failed = true;
         }
     }


### PR DESCRIPTION
This PR brings a couple of tiny improvements:

1. Adds the `AVX512VPOPCNTDQ` kernels to the standard compilation pipeline
2. Fixes `_aligned_malloc` symbol visibility, noticed when building with GCC 12 on Ubuntu
3. Uses masked loads to handle the tail of the AVX-512 kernel
4. Replaces `%llu` formatters with `%zu` for `size_t`